### PR TITLE
prefer-stable option should be present

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "email": "matheus.fidelis@superlogica.com"
     }],
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "guzzlehttp/guzzle": "^6.2@dev",
         "phpunit/phpunit": "^6.4@dev"


### PR DESCRIPTION
This option will allow the `minimum-stability: dev` flag to install stable packages, when found.

Without the new flag, the packages on the dependencies list have dev versions installed wrongly 